### PR TITLE
Use twisted.web.resource.NoResource

### DIFF
--- a/txrestapi/resource.py
+++ b/txrestapi/resource.py
@@ -1,8 +1,7 @@
 import re
 from itertools import ifilter
 from functools import wraps
-from twisted.web.resource import Resource
-from twisted.web.error import NoResource
+from twisted.web.resource import Resource, NoResource
 
 class _FakeResource(Resource):
     _result = ''

--- a/txrestapi/tests.py
+++ b/txrestapi/tests.py
@@ -4,10 +4,9 @@ import re
 import os.path
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
-from twisted.web.resource import Resource
+from twisted.web.resource import Resource, NoResource
 from twisted.web.server import Request, Site
 from twisted.web.client import getPage
-from twisted.web.error import NoResource
 from twisted.trial import unittest
 from .resource import APIResource
 from .methods import GET, PUT


### PR DESCRIPTION
twisted.web.errors.NoResource was removed in Twisted 12.2.0. I changed it to use twisted.web.resource.NoResource, which has been available from at least 10.0.0.
